### PR TITLE
Add feature spec aliases to syntax hightlight

### DIFF
--- a/syntax/rspec.vim
+++ b/syntax/rspec.vim
@@ -7,7 +7,7 @@
 runtime! syntax/ruby.vim
 unlet! b:current_syntax
 
-syntax keyword rspecGroupMethods context describe example it its let it_should_behave_like shared_examples_for subject it_behaves_like pending specify When Then Given Invariant
+syntax keyword rspecGroupMethods context describe example it its let it_should_behave_like shared_examples_for subject it_behaves_like pending specify When Then Given Invariant feature scenario given
 highlight link rspecGroupMethods Type
 
 syntax keyword rspecBeforeAndAfter after after_suite_parts append_after append_before before before_suite_parts prepend_after prepend_before around


### PR DESCRIPTION
Hey,

I've added these alias that are being used with feature specs.
https://www.relishapp.com/rspec/rspec-rails/docs/feature-specs/feature-spec
