### PR TITLE
Link Group Methods with Statement

### DIFF
--- a/syntax/rspec.vim
+++ b/syntax/rspec.vim
@@ -11,7 +11,7 @@ syntax keyword rspecGroupMethods context describe example it its let it_should_b
 highlight link rspecGroupMethods Statement
 
 syntax keyword rspecBeforeAndAfter after after_suite_parts append_after append_before before before_suite_parts prepend_after prepend_before around
-highlight link rspecBeforeAndAfter Statement
+highlight link rspecBeforeAndAfter Identifier
 
 syntax keyword rspecMocks double mock stub stub_chain
 highlight link rspecMocks Constant


### PR DESCRIPTION
I think is strange the `it`, `context` and `describe` use the same color of `Constants`. IMHO make more sense this words get the same color of `end`.
