### PR TITLE
Add expect_any_instance_of keyword

### DIFF
--- a/syntax/rspec.vim
+++ b/syntax/rspec.vim
@@ -22,7 +22,7 @@ highlight link rspecMockMethods Function
 syntax keyword rspecKeywords should should_not should_not_receive should_receive
 highlight link rspecKeywords Constant
 
-syntax keyword rspecMatchers be change eql equal exist expect allow allow_any_instance_of receive have have_at_least have_at_most have_exactly include match matcher raise_error raise_exception respond_to satisfy throw_symbol to to_not not_to when wrap_expectation
+syntax keyword rspecMatchers be change eql equal exist expect expect_any_instance_of allow allow_any_instance_of receive have have_at_least have_at_most have_exactly include match matcher raise_error raise_exception respond_to satisfy throw_symbol to to_not not_to when wrap_expectation
 syntax match rspecMatchers /\<\(be\|have\)_\w\+\>/
 highlight link rspecMatchers Function
 


### PR DESCRIPTION
I added a new keyword for [`expect_any_instance_of`](https://www.relishapp.com/rspec/rspec-mocks/docs/message-expectations/expect-a-message-on-any-instance-of-a-class), similar to `allow_any_instance_of`.

Thanks again for this awesome syntax plugin!
