### PR TITLE
Add described_class and is_expected keywords

### DIFF
--- a/syntax/rspec.vim
+++ b/syntax/rspec.vim
@@ -22,7 +22,7 @@ highlight link rspecMockMethods Function
 syntax keyword rspecKeywords should should_not should_not_receive should_receive
 highlight link rspecKeywords Constant
 
-syntax keyword rspecMatchers be change eql equal errors_on exist expect expect_any_instance_of allow allow_any_instance_of receive have have_at_least have_at_most have_exactly include match matcher raise_error raise_exception respond_to satisfy throw_symbol to to_not not_to when wrap_expectation
+syntax keyword rspecMatchers described_class is_expected be change eql equal errors_on exist expect expect_any_instance_of allow allow_any_instance_of receive have have_at_least have_at_most have_exactly include match matcher raise_error raise_exception respond_to satisfy throw_symbol to to_not not_to when wrap_expectation
 
 " rspec-mongoid exclusive matchers
 syntax keyword rspecMatchers embed_one embed_many belong_to validate_format_of validate_associated validate_exclusion_of validate_inclusion_of validate_length_of custom_validate accept_nested_attributes_for


### PR DESCRIPTION
`described_class` is an existing RSpec keyword, `is_expected` is new in RSpec 3
