### PR TITLE
added skip to syntax

### DIFF
--- a/syntax/rspec.vim
+++ b/syntax/rspec.vim
@@ -7,7 +7,7 @@
 runtime! syntax/ruby.vim
 unlet! b:current_syntax
 
-syntax keyword rspecGroupMethods context describe example it its let let\! it_should_behave_like shared_examples shared_examples_for subject it_behaves_like pending specify When Then Given Invariant feature scenario given given\!
+syntax keyword rspecGroupMethods context describe example it its let let\! it_should_behave_like shared_examples shared_examples_for subject it_behaves_like pending skip specify When Then Given Invariant feature scenario given given\!
 highlight link rspecGroupMethods Statement
 
 syntax keyword rspecBeforeAndAfter after after_suite_parts append_after append_before before before_suite_parts prepend_after prepend_before around


### PR DESCRIPTION
with rspec3 instead of pending people may use skip, so I added it to the same line of syntax where pending was (the "rspecGroupMethods").
