### PR TITLE
Respect `assigns`

### DIFF
--- a/syntax/rspec.vim
+++ b/syntax/rspec.vim
@@ -24,7 +24,7 @@ highlight link rspecMockMethods Function
 syntax keyword rspecKeywords should should_not should_not_receive should_receive
 highlight link rspecKeywords Constant
 
-syntax keyword rspecMatchers described_class is_expected be change eq eql equal errors_on exist expect expect_any_instance_of allow allow_any_instance_of receive have have_at_least have_at_most have_exactly include match matcher raise_error raise_exception respond_to satisfy throw_symbol to to_not not_to when wrap_expectation
+syntax keyword rspecMatchers described_class is_expected be change eq eql equal errors_on exist expect expect_any_instance_of allow allow_any_instance_of receive have have_at_least have_at_most have_exactly include match matcher raise_error raise_exception respond_to satisfy throw_symbol to to_not not_to when wrap_expectation assigns
 
 " rspec-mongoid exclusive matchers
 syntax keyword rspecMatchers embed_one embed_many belong_to validate_format_of validate_associated validate_exclusion_of validate_inclusion_of validate_length_of custom_validate accept_nested_attributes_for


### PR DESCRIPTION
`assigns` is coming from rspec-rails, so unsure whether you'd like to include that in. Feel free to close if that is in conflict with the goals of the plugin.