### PR TITLE
Enable for shared examples/contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@ If you don't have a preferred installation method check out
 
 ## Usage
 
-By default this syntax is used with all `*_spec.rb` files. If you don't
-follow this pattern use something like:
+By default this syntax is used with all files matching one of these patterns:
+
+- `*_spec.rb`
+- `*_shared_examples.rb`
+- `*_shared_context.rb`
+
+If you don't follow this pattern use something like:
 
 ```vim
 autocmd BufNewFile,BufRead *_foo.rb set syntax=rspec

--- a/after/ftdetect/rspec.vim
+++ b/after/ftdetect/rspec.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *_spec.rb set syntax=rspec filetype=rspec.ruby
+autocmd BufNewFile,BufRead *_spec.rb,*_shared_examples.rb,*_shared_context.rb set syntax=rspec filetype=rspec.ruby


### PR DESCRIPTION
RSpec also uses the `*_shared_examples.rb` and `*_shared_context.rb` naming conventions, so it would be nice to support these too.